### PR TITLE
fix: misc fixes and alignments in 601

### DIFF
--- a/features/601.ngsild.Intro_Stellio.feature
+++ b/features/601.ngsild.Intro_Stellio.feature
@@ -31,7 +31,7 @@ Feature: test tutorial 601 Introduction to Linked Data (Stellio)
       And  I set header Content-Type to application/ld+json
       And  I set the body request as described in <file>
       And  I perform the request
-      Then I receive a HTTP response with the following Orion-LD data
+      Then I receive a HTTP response with the following Stellio data
         | Status-Code | Location   |
         | 201         | <location> |
 
@@ -41,127 +41,66 @@ Feature: test tutorial 601 Introduction to Linked Data (Stellio)
         | request601-03.json | /ngsi-ld/v1/entities/urn:ngsi-ld:Building:store002 |
 
 
-#
-#   Request 4
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "http://schema.org/address" is instead of "https://schema.org/address"
-#           - the structured attribute
-#                           "https://uri.fiware.org/ns/dataModels#category": {
-#                                "type": "Property",
-#                                "value": ["commercial"]
-#                                }, is instead of
-#                           "https://smart-data-models.github.io/dataModels/terms.jsonld#/definitions/category": {
-#                                "type": "Property",
-#                                "value": "commercial"
-#                                } and is in a wrong position.
-#
     Scenario: [4] OBTAIN ENTITY DATA BY FQN TYPE
-      When  I send GET HTTP request to "http://localhost:1026/ngsi-ld/v1/entities?type=https://uri.fiware.org/ns/dataModels%23Building"
-      Then  I receive a HTTP "200" response code from Stellio with the body equal to "response601-04.json"
+      When I prepare a GET HTTP request for "obtaining an entity data" to "http://localhost:1026/ngsi-ld/v1/entities"
+      And  I set header Accept to application/ld+json
+      And  the params equal to "type=https://smartdatamodels.org/dataModel.Building/Building"
+      And  I perform the request
+      Then I receive a HTTP "200" response code from Stellio with the body equal to "response601-04-array.json"
 
 
-#
-#   Request 5
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "http://schema.org/address" is instead of "https://schema.org/address"
-#           - the structured attribute
-#                           "https://uri.fiware.org/ns/dataModels#category": {
-#                                "type": "Property",
-#                                "value": ["commercial"]
-#                                }, is instead of
-#                           "https://smart-data-models.github.io/dataModels/terms.jsonld#/definitions/category": {
-#                                "type": "Property",
-#                                "value": "commercial"
-#                                } and is in a wrong position.
-#
     Scenario: [5] OBTAIN ENTITY DATA BY ID
-      When  I send GET HTTP request to "http://localhost:1026/ngsi-ld/v1/entities/urn:ngsi-ld:Building:store001"
+      When  I prepare a GET HTTP request for "obtaining entity data by Id" to "http://localhost:1026/ngsi-ld/v1/entities/urn:ngsi-ld:Building:store001"
+      And   I set header Accept to application/ld+json
+      And   I perform the request
       Then  I receive a HTTP "200" response code from Stellio with the body equal to "response601-05.json"
 
 
-#
-#   Request 6
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           - in the file "response601_06" the first entity is as provided by Stellio while the second entity
-#             is left as expected in the tutorial to let understand the differences to make easier the correct the tutorial.
-#     Note: the request itself in the tutorial is wrong as the url appears twice.
-#
     Scenario: [6] OBTAIN ENTITY DATA BY TYPE
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$options$keyValues"
+      When  I set the "Accept" header with the value "application/ld+json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   the params equal to "type=Building"
+      And   the params equal to "options=keyValues"
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-06.json"
 
 
-#
-#   Request 7
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           The file "response601_07" is updated as provided by Stellio to let understand how to correct the tutorial.
-#
     Scenario: [7] FILTER CONTEXT DATA BY COMPARING THE VALUES OF AN ATTRIBUTE
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$q$name=="Checkpoint Markt"$options$keyValues"
+      When  I set the "Accept" header with the value "application/ld+json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities?type=Building&q=name==%22Checkpoint%20Markt%22&options=keyValues"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-07.json"
 
 
-#
-#   Request 8
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           The file "response601_08" is left unchanged.
-#
     Scenario: [8] FILTER CONTEXT DATA BY COMPARING THE VALUES OF AN ATTRIBUTE IN AN ARRAY
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$q$category=="commercial","office"$options$keyValues"
+      When  I set the "Accept" header with the value "application/ld+json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities?type=Building&q=category==%22commercial%22,%22office%22&options=keyValues"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-08.json"
 
 
-#
-#   Request 9
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           The file "response601_09" is left unchanged.
-#
     Scenario: [9] FILTER CONTEXT DATA BY COMPARING THE VALUES OF A SUB-ATTRIBUTE
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$q$address[addressLocality]=="Kreuzberg"$options$keyValues"
+      When  I set the "Accept" header with the value "application/ld+json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities?type=Building&q=address%5BaddressLocality%5D==%22Kreuzberg%22&options=keyValues"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-09.json"
 
 
-#
-#   Request 10
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           The file "response601_10" is left unchanged.
-#
     Scenario: [10] FILTER CONTEXT DATA BY QUERYING METADATA
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$q$address.verified==true$options$keyValues"
+      When  I set the "Accept" header with the value "application/json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities?type=Building&q=address.verified==true&options=keyValues"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-10.json"
 
 
-#
-#   Request 11
-#     Note: the body response is quite different from what expected. In particular:
-#           - the attribute "@context" is at the beginning of the entity and not at the end as expected
-#           - the attribute "category" is of a wrong type and misplaced.
-#           The file "response601_11" is left unchanged.
-#
     Scenario: [11] FILTER CONTEXT DATA BY COMPARING THE VALUES OF A GEO:JSON ATTRIBUTE
-      When  I send GET HTTP request to Stellio at "http://localhost:1026/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://smartdatamodels.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/json"'
-      And   With parameters "type$Building$geometry$Point$coordinates$[13.3777,52.5162]$georel$near;maxDistance==2000$options$keyValues"
+      When  I set the "Accept" header with the value "application/json"
+      And   I set the "Link" header with the value "<https://smart-data-models.github.io/dataModel.Building/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json""
+      And   I set the url to "http://localhost:1026/ngsi-ld/v1/entities?type=Building&geometry=Point&coordinates=%5B13.3777,52.5162%5D&georel=near%3BmaxDistance==2000&options=keyValues"
+      And   I send a GET HTTP request to that url
       Then  I receive from Stellio "200" response code with the body equal to "response601-11.json"

--- a/features/data/601.LD-Intro/request601-02.json
+++ b/features/data/601.LD-Intro/request601-02.json
@@ -2,7 +2,7 @@
     "id": "urn:ngsi-ld:Building:store001",
     "type": "Building",
     "category": {
-        "type": "VocabularyProperty",
+        "type": "VocabProperty",
         "vocab": "commercial"
     },
     "address": {
@@ -31,6 +31,6 @@
     },
     "@context": [
         "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
     ]
 }

--- a/features/data/601.LD-Intro/request601-03.json
+++ b/features/data/601.LD-Intro/request601-03.json
@@ -2,7 +2,7 @@
     "id": "urn:ngsi-ld:Building:store002",
     "type": "Building",
     "category": {
-        "type": "VocabularyProperty",
+        "type": "VocabProperty",
         "vocab": "commercial"
     },
     "address": {
@@ -31,6 +31,6 @@
     },
     "@context": [
         "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
     ]
 }

--- a/features/data/601.LD-Intro/response601-04-array.json
+++ b/features/data/601.LD-Intro/response601-04-array.json
@@ -1,10 +1,10 @@
 [
     {
-        "@context": ["https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.7.jsonld"],
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
         "id": "urn:ngsi-ld:Building:store001",
         "type": "https://smartdatamodels.org/dataModel.Building/Building",
         "https://smartdatamodels.org/dataModel.Building/category": {
-            "type": "VocabularyProperty",
+            "type": "VocabProperty",
             "vocab": "commercial"
         },
         "https://smartdatamodels.org/address": {
@@ -33,11 +33,11 @@
         }
     },
     {
-        "@context": ["https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.7.jsonld"],
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
         "id": "urn:ngsi-ld:Building:store002",
         "type": "https://smartdatamodels.org/dataModel.Building/Building",
         "https://smartdatamodels.org/dataModel.Building/category": {
-            "type": "VocabularyProperty",
+            "type": "VocabProperty",
             "vocab": "commercial"
         },
         "https://smartdatamodels.org/address": {

--- a/features/data/601.LD-Intro/response601-04.json
+++ b/features/data/601.LD-Intro/response601-04.json
@@ -1,10 +1,10 @@
 [
     {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
         "id": "urn:ngsi-ld:Building:store001",
         "type": "https://smartdatamodels.org/dataModel.Building/Building",
         "https://smartdatamodels.org/dataModel.Building/category": {
-            "type": "VocabularyProperty",
+            "type": "VocabProperty",
             "vocab": "commercial"
         },
         "https://smartdatamodels.org/address": {
@@ -33,11 +33,11 @@
         }
     },
     {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
         "id": "urn:ngsi-ld:Building:store002",
         "type": "https://smartdatamodels.org/dataModel.Building/Building",
         "https://smartdatamodels.org/dataModel.Building/category": {
-            "type": "VocabularyProperty",
+            "type": "VocabProperty",
             "vocab": "commercial"
         },
         "https://smartdatamodels.org/address": {

--- a/features/data/601.LD-Intro/response601-05.json
+++ b/features/data/601.LD-Intro/response601-05.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
   "id": "urn:ngsi-ld:Building:store001",
   "type": "https://smartdatamodels.org/dataModel.Building/Building",
   "https://smartdatamodels.org/address": {
@@ -16,7 +16,7 @@
     }
   },
   "https://smartdatamodels.org/dataModel.Building/category": {
-    "type": "VocabularyProperty",
+    "type": "VocabProperty",
     "vocab": "commercial"
   },
   "https://smartdatamodels.org/name": {

--- a/features/data/601.LD-Intro/response601-06.json
+++ b/features/data/601.LD-Intro/response601-06.json
@@ -2,7 +2,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store001",
         "type": "Building",
@@ -24,7 +24,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store002",
         "type": "Building",

--- a/features/data/601.LD-Intro/response601-07.json
+++ b/features/data/601.LD-Intro/response601-07.json
@@ -2,7 +2,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store002",
         "type": "Building",

--- a/features/data/601.LD-Intro/response601-08.json
+++ b/features/data/601.LD-Intro/response601-08.json
@@ -2,7 +2,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store001",
         "type": "Building",
@@ -24,7 +24,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store002",
         "type": "Building",

--- a/features/data/601.LD-Intro/response601-09.json
+++ b/features/data/601.LD-Intro/response601-09.json
@@ -2,7 +2,7 @@
     {
         "@context": [
             "https://smart-data-models.github.io/dataModel.Building/context.jsonld",
-            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+            "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
         ],
         "id": "urn:ngsi-ld:Building:store002",
         "type": "Building",


### PR DESCRIPTION
- align VocabProperty on v1.8 definition (https://cim.etsi.org/NGSI-LD/official/9-tabcontext-information-management-framework.html#tabngsi-ld-vocabproperty-representations)
- remove context from response when asking for JSON content type (in this case, the context is provided as a Link header)
- update core context to v1.8 in expectations (they were using core context v1.6 in which Vocab(ulary)Property does not exist yet, so it can't work)
- align scenarios in Stellio features with ones from Orion-LD (I guess the same should be done for Scorpio)