### PR TITLE
fix: misc fixes and alignments in 602

### DIFF
--- a/features/602.ngsild.RelationshipsAndDataModels_Stellio.feature
+++ b/features/602.ngsild.RelationshipsAndDataModels_Stellio.feature
@@ -4,11 +4,11 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
 #   Parameters to be considered (aka INTERESTING_FEATURES_STRINGS)
 #
     url: https://fiware-tutorials.readthedocs.io/en/latest/relationships-linked-data.html
-    git-clone: https://github.com/FIWARE/tutorials.Relationships-Linked-Data.git
+    git-clone: https://github.com/stellio-hub/tutorials.Relationships-Linked-Data.git
     git-directory: /tmp/tutorials.Relationships-Linked-Data
 
-    shell-commands: git checkout NGSI-v2; ./services create; ./services stellio
-    clean-shell-commands: ./services stop
+    shell-commands: git checkout feature/align-vocab-property; ./services stellio
+    #clean-shell-commands: ./services stop
 
 #   Overall Note: The tutorial does not say anything out the response code expected.
 #                Even the success code is not always the same! It takes 200, 201, 204 depending on the API
@@ -18,54 +18,38 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
         Given I set the tutorial 602
 
 
-#
-#   Request 1
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) attribute '@context' expected 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.3.jsonld'
-#                current 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'. In this respect
-#                the text itself of the tutorial shall be corrected
-#             2) attribute 'name' expected first, instead it is second after attribute 'https://schema.org/address'
-#
     Scenario: [1] DISPLAY ALL entities of a given type (BUILDINGS)
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities"
-      And   With header 'NA$NA'
-      And   With parameters "type$https://uri.fiware.org/ns/data-models#Building$options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining an entity data" to "http://localhost:8080/ngsi-ld/v1/entities"
+      And   I set header Accept to application/ld+json
+      And   the params equal to "type=https://uri.fiware.org/ns/data-models#Building"
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-01.json"
 
 
-#
-#   Request 2
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) attribute 'name' expected first, instead it is last
-#
     Scenario: [2] DISPLAY ALL entities of a given type (PRODUCT)
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
-      And   With parameters "type$https://fiware.github.io/tutorials.Step-by-Step/schema/Product$options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining entities data" to "http://localhost:8080/ngsi-ld/v1/entities"
+      And   I set header Link to <http://context/user-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+      And   the params equal to "type=https://fiware.github.io/tutorials.Step-by-Step/schema/Product"
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-02.json"
 
 
-#
-#   Request 3
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) attribute 'name' expected first, instead it is second after 'maxCapacity' attribute
-#
     Scenario: [3] DISPLAY ALL entities of a given type (SHELF)
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities"
-      And   With header 'Link$<https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
-      And   With parameters "type$Shelf$options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining entities data" to "http://localhost:8080/ngsi-ld/v1/entities"
+      And   I set header Link to <http://context/user-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+      And   the params equal to "type=Shelf"
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-03.json"
 
 
-#
-#   Request 4
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) attributes order completely mixed-up. Expected: name, maxCapacity, location, Current: location, maxCapacity, name
-#
     Scenario: [4] OBTAIN SHELF INFORMATION
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001/"
-      And   With header 'Link$<https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
-      And   With parameters "options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining an entity data" to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001"
+      And   I set header Link to <http://context/user-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-04.json"
 
 
@@ -73,48 +57,31 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
 #   Request 5
 #
     Scenario Outline: [5] ADDING 1-1 RELATIONSHIPS
-    When I send POST HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001/attrs"
-#    And  With the post header "fiware-servicepath": " /"
-    And  With the post header "NA": "NA"
-    And  With the body request described in an Stellio file "<file>"
-    Then I receive a HTTP response with the following Stellio data
-      | Status-Code | Location   | Connection | fiware-correlator |
-      | 204         | <location> | Keep-Alive | Any               |
+    When  I prepare a POST HTTP request for "creating an entity" to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001/attrs"
+    And   I set header Content-Type to application/ld+json
+    And   I set the body request as described in <file>
+    And   I perform the request
+    Then  I receive a HTTP response with the following Stellio data
+      | Status-Code | Location   |
+      | 204         | <location> |
 
     Examples:
       | file               | location |
       | request602-05.json | Any      |
 
 
-#
-#   Request 6
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) attribute '@context'
-#                  expected 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.3.jsonld'
-#                  current 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld'
-#             2) expected attributes: name, locatedIn, maxCapacity, numberOfItems, stocks, location,
-#                current attributes: location, maxCapacity, name
-#             3) order of attributes of locatedIn is mixedup.
-#                expected: type, object, installedBy, requestedBy, statusOfWork
-#                current: object, type, requestedBy, installedBy, statusOfWork
-#             4) attributes requestedBy, installedBy, statusOfWork miss the indication of the schema (https://fiware.github.io/tutorials.Step-by-Step/schema/)
-#
     Scenario: [6] OBTAIN THE UPDATED SHELF
       When I send GET HTTP request to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001"
       Then I receive a HTTP "200" response code from Stellio with the body equal to "response602-06.json"
 
 
-#
-#   Request 7
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) wrong value for attribute '@context.
-#                expected: 'https://fiware.github.io/tutorials.Step-by-Step/datamodels-context.jsonld'
-#                current: 'https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld'
-#
     Scenario: [7] FIND THE STORE IN WHICH A SPECIFIC SHELF IS LOCATED
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001/"
-      And   With header 'Link$<https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
-      And   With parameters "attrs$locatedIn$options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining an entity data" to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Shelf:unit001"
+      And   I set header Link to <http://context/user-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+      And   I set header Accept to application/ld+json
+      And   the params equal to "attrs=locatedIn"
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-07.json"
 
 
@@ -132,12 +99,13 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
 #   Request 9
 #
     Scenario Outline: [9] ADDING 1-MANY RELATIONSHIP
-      When I send POST HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Building:store001/attrs"
-      And  With the post header "NA": "NA"
-      And  With the body request described in an Stellio file "<file>"
-      Then I receive a HTTP response with the following Stellio data
-        | Status-Code | Location   | Connection | fiware-correlator |
-        | 204         | <location> | Keep-Alive | Any               |
+      When  I prepare a POST HTTP request for "adding new attribute" to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:Building:store001/attrs"
+      And   I set header Content-Type to application/ld+json
+      And   I set the body request as described in <file>
+      And   I perform the request
+      Then  I receive a HTTP response with the following Stellio data
+        | Status-Code | Location   |
+        | 204         | <location> |
 
       Examples:
         | file               | location |
@@ -158,12 +126,13 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
 #   Request 11
 #
     Scenario Outline: [11] CREATING COMPLEX RELATIONSHIPS
-      When I send POST HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/"
-      And  With the post header "NA": "NA"
-      And  With the body request described in an Stellio file "<file>"
-      Then I receive a HTTP response with the following Stellio data
-        | Status-Code | Location   | Connection | fiware-correlator |
-        | 201         | <location> | Keep-Alive | Any               |
+      When  I prepare a POST HTTP request for "creating an entity" to "http://localhost:8080/ngsi-ld/v1/entities/"
+      And   I set header Content-Type to application/ld+json
+      And   I set the body request as described in <file>
+      And   I perform the request
+      Then  I receive a HTTP response with the following Stellio data
+        | Status-Code | Location   |
+        | 201         | <location> |
 
       Examples:
         | file               | location |
@@ -190,17 +159,9 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
       Then  I receive from Stellio "200" response code with the body equal to "response602-13.json"
 
 
-#
-#   Request 14
-#       Note: The expected body in the Tutorial has the following differences with respect to the current Stellio version:
-#             1) wrong value for attribute '@context.
-#                expected: 'https://fiware.github.io/tutorials.Step-by-Step/datamodels-context.jsonld'
-#                current: 'https://fiware.github.io/tutorials.Step-by-Step/tutorials-context.jsonld'
-#             2) expected attributes order: type, orderDate, orderedProduct, requestedBy, requestedFor, stockCount
-#                current attributes order: type, requestedFor, requestedBy, orderedProduct, stockCount, orderDate
-#
     Scenario: [14] OBTAIN STOCK ORDER
-      When  I send GET HTTP request to Stellio at "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:StockOrder:001"
-      And   With header 'NA$NA'
-      And   With parameters "options$keyValues"
+      When  I prepare a GET HTTP request for "obtaining an entity data" to "http://localhost:8080/ngsi-ld/v1/entities/urn:ngsi-ld:StockOrder:001"
+      And   I set header Accept to application/ld+json
+      And   the params equal to "options=keyValues"
+      And   I perform the request
       Then  I receive from Stellio "200" response code with the body equal to "response602-14.json"

--- a/features/602.ngsild.RelationshipsAndDataModels_Stellio.feature
+++ b/features/602.ngsild.RelationshipsAndDataModels_Stellio.feature
@@ -4,11 +4,11 @@ Feature: test tutorial 602 Linked Data: Relationships and Data Models (Stellio)
 #   Parameters to be considered (aka INTERESTING_FEATURES_STRINGS)
 #
     url: https://fiware-tutorials.readthedocs.io/en/latest/relationships-linked-data.html
-    git-clone: https://github.com/stellio-hub/tutorials.Relationships-Linked-Data.git
+    git-clone: https://github.com/FIWARE/tutorials.Relationships-Linked-Data.git
     git-directory: /tmp/tutorials.Relationships-Linked-Data
 
-    shell-commands: git checkout feature/align-vocab-property; ./services stellio
-    #clean-shell-commands: ./services stop
+    shell-commands: git checkout NGSI-v2; ./services stellio
+    clean-shell-commands: ./services stop
 
 #   Overall Note: The tutorial does not say anything out the response code expected.
 #                Even the success code is not always the same! It takes 200, 201, 204 depending on the API

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-01.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-01.json
@@ -1,16 +1,16 @@
 [
   {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
     "id": "urn:ngsi-ld:Building:store001",
     "type": "https://uri.fiware.org/ns/data-models#Building",
     "https://uri.fiware.org/ns/data-models#category": {
-      "vocab": "https://wiki.openstreetmap.org/wiki/Tag:building%3Dcommercial"
+      "vocab": "openstreetmap:commercial"
     },
     "https://schema.org/address": {
-      "streetAddress": "Bornholmer Straße 65",
-      "addressRegion": "Berlin",
-      "addressLocality": "Prenzlauer Berg",
-      "postalCode": "10439"
+      "https://schema.org/streetAddress": "Bornholmer Straße 65",
+      "https://schema.org/addressRegion": "Berlin",
+      "https://schema.org/addressLocality": "Prenzlauer Berg",
+      "https://schema.org/postalCode": "10439"
     },
     "location": {
       "type": "Point",
@@ -22,17 +22,17 @@
     "https://schema.org/name": "Bösebrücke Einkauf"
   },
   {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
     "id": "urn:ngsi-ld:Building:store002",
     "type": "https://uri.fiware.org/ns/data-models#Building",
     "https://uri.fiware.org/ns/data-models#category": {
-      "vocab": "https://wiki.openstreetmap.org/wiki/Tag:building%3Dcommercial"
+      "vocab": "openstreetmap:commercial"
     },
     "https://schema.org/address": {
-      "streetAddress": "Friedrichstraße 44",
-      "addressRegion": "Berlin",
-      "addressLocality": "Kreuzberg",
-      "postalCode": "10969"
+      "https://schema.org/streetAddress": "Friedrichstraße 44",
+      "https://schema.org/addressRegion": "Berlin",
+      "https://schema.org/addressLocality": "Kreuzberg",
+      "https://schema.org/postalCode": "10969"
     },
     "location": {
       "type": "Point",
@@ -44,17 +44,17 @@
     "https://schema.org/name": "Checkpoint Markt"
   },
   {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
     "id": "urn:ngsi-ld:Building:store003",
     "type": "https://uri.fiware.org/ns/data-models#Building",
     "https://uri.fiware.org/ns/data-models#category": {
-      "vocab": "https://wiki.openstreetmap.org/wiki/Tag:building%3Dcommercial"
+      "vocab": "openstreetmap:commercial"
     },
     "https://schema.org/address": {
-      "streetAddress": "Mühlenstrasse 10",
-      "addressRegion": "Berlin",
-      "addressLocality": "Friedrichshain",
-      "postalCode": "10243"
+      "https://schema.org/streetAddress": "Mühlenstrasse 10",
+      "https://schema.org/addressRegion": "Berlin",
+      "https://schema.org/addressLocality": "Friedrichshain",
+      "https://schema.org/postalCode": "10243"
     },
     "location": {
       "type": "Point",
@@ -66,17 +66,17 @@
     "https://schema.org/name": "East Side Galleria"
   },
   {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
     "id": "urn:ngsi-ld:Building:store004",
     "type": "https://uri.fiware.org/ns/data-models#Building",
     "https://uri.fiware.org/ns/data-models#category": {
-      "vocab": "https://wiki.openstreetmap.org/wiki/Tag:building%3Dcommercial"
+      "vocab": "openstreetmap:commercial"
     },
     "https://schema.org/address": {
-      "streetAddress": "Panoramastraße 1A",
-      "addressRegion": "Berlin",
-      "addressLocality": "Mitte",
-      "postalCode": "10178"
+      "https://schema.org/streetAddress": "Panoramastraße 1A",
+      "https://schema.org/addressRegion": "Berlin",
+      "https://schema.org/addressLocality": "Mitte",
+      "https://schema.org/postalCode": "10178"
     },
     "location": {
       "type": "Point",

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-03.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-03.json
@@ -7,7 +7,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.398611,
+        13.3986112,
         52.554699
       ]
     }
@@ -20,7 +20,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.398722,
+        13.3987221,
         52.554664
       ]
     }
@@ -33,7 +33,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.398722,
+        13.3987221,
         52.554664
       ]
     }
@@ -72,7 +72,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.444711,
+        13.4447112,
         52.503199
       ]
     }
@@ -85,7 +85,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.444722,
+        13.4447221,
         52.503164
       ]
     }
@@ -98,7 +98,7 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.444722,
+        13.4447221,
         52.503164
       ]
     }
@@ -124,8 +124,8 @@
     "location": {
       "type": "Point",
       "coordinates": [
-        13.409411,
-        52.520803
+        13.4094111,
+        52.5208028
       ]
     }
   }

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-04.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-04.json
@@ -5,6 +5,6 @@
     "maxCapacity": 50,
     "location": {
         "type": "Point",
-        "coordinates": [13.398611, 52.554699]
+        "coordinates": [13.3986112, 52.554699]
     }
 }

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-06-AsTutorial.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-06-AsTutorial.json
@@ -38,7 +38,7 @@
         "type": "GeoProperty",
         "value": {
             "type": "Point",
-            "coordinates": [13.398611, 52.554699]
+            "coordinates": [13.3986112, 52.554699]
         }
     }
 }

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-06.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-06.json
@@ -5,7 +5,7 @@
         "type": "GeoProperty",
         "value": {
             "type": "Point",
-            "coordinates": [13.398611, 52.554699]
+            "coordinates": [13.3986112, 52.554699]
         }
     },
     "https://fiware.github.io/tutorials.Step-by-Step/schema/maxCapacity": {

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-07.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-07.json
@@ -1,7 +1,7 @@
 {
     "@context": [
         "http://context/user-context.jsonld",
-        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld"
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"
     ],
     "id": "urn:ngsi-ld:Shelf:unit001",
     "type": "Shelf",

--- a/features/data/602.LD-RelationshipsAndDataModels/response602-14.json
+++ b/features/data/602.LD-RelationshipsAndDataModels/response602-14.json
@@ -1,5 +1,5 @@
 {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.6.jsonld",
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
     "id": "urn:ngsi-ld:StockOrder:001",
     "type": "https://fiware.github.io/tutorials.Step-by-Step/schema/StockOrder",
     "https://fiware.github.io/tutorials.Step-by-Step/schema/orderDate": {


### PR DESCRIPTION
- update core context to v1.8 in expectations (they were using core context v1.6 in which Vocab(ulary)Property does not exist yet, so it can't work)
- fix expected payload in the 1st request (see [this link](https://tinyurl.com/602-ld-response-01) for a live demo)
- align scenarios in Stellio features with ones from Orion-LD (I guess the same should be done for Scorpio)
- some latitudes and longitudes were truncated compared to what they are when created